### PR TITLE
DRAFT PR for sharing host-driven AoT development

### DIFF
--- a/cmake/modules/StandaloneCrt.cmake
+++ b/cmake/modules/StandaloneCrt.cmake
@@ -32,6 +32,8 @@ if(USE_MICRO)
          "include/tvm/runtime/crt *.h -> include/tvm/runtime/crt"
          "src/runtime/crt Makefile -> ."
          "src/runtime/crt/include *.h -> include"
+         "src/runtime/crt/aot_executor *.c -> src/runtime/crt/aot_executor"
+         "src/runtime/crt/aot_executor_module *.c -> src/runtime/crt/aot_executor_module"
          "src/runtime/crt/common *.c -> src/runtime/crt/common"
          "src/runtime/crt/graph_executor *.c -> src/runtime/crt/graph_executor"
          "src/runtime/crt/graph_executor_module *.c -> src/runtime/crt/graph_executor_module"

--- a/include/tvm/runtime/c_runtime_api.h
+++ b/include/tvm/runtime/c_runtime_api.h
@@ -298,7 +298,7 @@ TVM_DLL int TVMCbArgToReturn(TVMValue* value, int* code);
  * \param type_codes The type codes of the arguments
  * \param num_args Number of arguments.
  * \param ret The return value handle.
- * \param resource_handle The handle additional resouce handle from fron-end.
+ * \param resource_handle The handle additional resouce handle from front-end.
  * \return 0 if success, -1 if failure happens, set error via TVMAPISetLastError.
  * \sa TVMCFuncSetReturn
  */
@@ -307,7 +307,7 @@ typedef int (*TVMPackedCFunc)(TVMValue* args, int* type_codes, int num_args, TVM
 
 /*!
  * \brief C callback to free the resource handle in C packed function.
- * \param resource_handle The handle additional resouce handle from fron-end.
+ * \param resource_handle The handle additional resouce handle from front-end.
  */
 typedef void (*TVMPackedCFuncFinalizer)(void* resource_handle);
 

--- a/include/tvm/runtime/crt/aot_executor.h
+++ b/include/tvm/runtime/crt/aot_executor.h
@@ -30,6 +30,7 @@ extern "C" {
 
 #include <dlpack/dlpack.h>
 #include <tvm/runtime/metadata.h>
+#include <tvm/runtime/crt/internal/common/ndarray.h>
 
 typedef struct TVMMetadata TVMMetadata;
 
@@ -40,6 +41,9 @@ typedef struct TVMAotExecutor {
   TVMModuleHandle module_handle;
   /*! \brief The device type */
   DLDevice device;
+  /*! \brief List of allocated arguments, input(s), output(s), and pool(s)*/
+  TVMNDArray* args;
+  int64_t num_args;
 } TVMAotExecutor;
 
 /*!

--- a/include/tvm/runtime/crt/aot_executor.h
+++ b/include/tvm/runtime/crt/aot_executor.h
@@ -59,7 +59,13 @@ int TVMAotExecutor_Create(TVMModuleHandle module_handle,
 
 int TVMAotExecutor_Release(TVMAotExecutor* executor, const DLDevice device);
 
+int TVMAotExecutor_GetNumInputs(TVMAotExecutor* executor);
+
+int TVMAotExecutor_GetNumOutputs(TVMAotExecutor* executor);
+
 int TVMAotExecutor_GetInputIndex(TVMAotExecutor* executor, const char* name);
+
+int TVMAotExecutor_Run(TVMAotExecutor* executor);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/tvm/runtime/crt/aot_executor.h
+++ b/include/tvm/runtime/crt/aot_executor.h
@@ -28,6 +28,34 @@
 extern "C" {
 #endif
 
+#include <dlpack/dlpack.h>
+#include <tvm/runtime/metadata.h>
+
+typedef struct TVMMetadata TVMMetadata;
+
+typedef struct TVMAotExecutor {
+  /*! \brief The top-level metadata structure */
+  TVMMetadata* metadata;
+  /*! \brief The code module that contains both host and device code */
+  TVMModuleHandle module_handle;
+  /*! \brief The device type */
+  DLDevice device;
+} TVMAotExecutor;
+
+/*!
+ * \brief Allocate a new AotExecutor with TVMPlatformMemoryAllocate and initialize it.
+ *
+ * \param module_handle TVM Module that exposes the functions to call.
+ * \param devices runtime execution device.
+ * \param executor Pointer which receives a pointer to the newly-created instance.
+ * \return 0 if successful.
+ */
+int TVMAotExecutor_Create(TVMModuleHandle module_handle,
+                          const DLDevice* devices, TVMAotExecutor** executor);
+
+int TVMAotExecutor_Release(TVMAotExecutor* executor, const DLDevice device);
+
+int TVMAotExecutor_GetInputIndex(TVMAotExecutor* executor, const char* name);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/tvm/runtime/crt/aot_executor.h
+++ b/include/tvm/runtime/crt/aot_executor.h
@@ -18,25 +18,19 @@
  */
 
 /*!
- * \file graph_executor_module.h
- * \brief Tiny graph executor that can run graph containing only tvm PackedFunc.
+ * \file aot_executor.h
+ * \brief AoT Executor
  */
-#ifndef TVM_RUNTIME_CRT_GRAPH_EXECUTOR_MODULE_H_
-#define TVM_RUNTIME_CRT_GRAPH_EXECUTOR_MODULE_H_
+#ifndef TVM_RUNTIME_CRT_AOT_EXECUTOR_H_
+#define TVM_RUNTIME_CRT_AOT_EXECUTOR_H_
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include <tvm/runtime/crt/error_codes.h>
-
-/*!
- * \brief Register the "tvm.graph_executor.create" constructor PackedFunc.
- */
-tvm_crt_error_t TVMGraphExecutorModule_Register();
 
 #ifdef __cplusplus
 }  // extern "C"
 #endif
 
-#endif  // TVM_RUNTIME_CRT_GRAPH_EXECUTOR_MODULE_H_
+#endif  // TVM_RUNTIME_CRT_AOT_EXECUTOR_H_

--- a/include/tvm/runtime/crt/aot_executor_module.h
+++ b/include/tvm/runtime/crt/aot_executor_module.h
@@ -18,11 +18,11 @@
  */
 
 /*!
- * \file graph_executor_module.h
- * \brief Tiny graph executor that can run graph containing only tvm PackedFunc.
+ * \file graph_executor.h
+ * \brief Tiny AoT executor
  */
-#ifndef TVM_RUNTIME_CRT_GRAPH_EXECUTOR_MODULE_H_
-#define TVM_RUNTIME_CRT_GRAPH_EXECUTOR_MODULE_H_
+#ifndef TVM_RUNTIME_CRT_AOT_EXECUTOR_MODULE_H_
+#define TVM_RUNTIME_CRT_AOT_EXECUTOR_MODULE_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,9 +31,9 @@ extern "C" {
 #include <tvm/runtime/crt/error_codes.h>
 
 /*!
- * \brief Register the "tvm.graph_executor.create" constructor PackedFunc.
+ * \brief Register the "tvm.aot_executor.create" constructor PackedFunc.
  */
-tvm_crt_error_t TVMGraphExecutorModule_Register();
+tvm_crt_error_t TVMAotExecutorModule_Register();
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/include/tvm/runtime/crt/error_codes.h
+++ b/include/tvm/runtime/crt/error_codes.h
@@ -42,7 +42,7 @@ typedef enum {
   kTvmErrorCategorySession = 4,
   kTvmErrorCategoryPlatform = 5,
   kTvmErrorCategoryGenerated = 6,
-  kTvmErrorCategoryGraphExecutor = 7,
+  kTvmErrorCategoryExecutor = 7,
   kTvmErrorCategoryFunctionCall = 8,
   kTvmErrorCategoryTimeEvaluator = 9,
 } tvm_crt_error_category_t;
@@ -84,10 +84,10 @@ typedef enum {
   // Common error codes returned from generated functions.
   kTvmErrorGeneratedInvalidStorageId = DEFINE_TVM_CRT_ERROR(kTvmErrorCategoryGenerated, 0),
 
-  // Graph executor
-  kTvmErrorGraphModuleAlreadyCreated = DEFINE_TVM_CRT_ERROR(kTvmErrorCategoryGraphExecutor, 0),
-  kTvmErrorGraphModuleBadContext = DEFINE_TVM_CRT_ERROR(kTvmErrorCategoryGraphExecutor, 1),
-  kTvmErrorGraphModuleNoSuchInput = DEFINE_TVM_CRT_ERROR(kTvmErrorCategoryGraphExecutor, 2),
+  // Graph or AoT executor
+  kTvmErrorExecutorModuleAlreadyCreated = DEFINE_TVM_CRT_ERROR(kTvmErrorCategoryExecutor, 0),
+  kTvmErrorExecutorModuleBadContext = DEFINE_TVM_CRT_ERROR(kTvmErrorCategoryExecutor, 1),
+  kTvmErrorExecutorModuleNoSuchInput = DEFINE_TVM_CRT_ERROR(kTvmErrorCategoryExecutor, 2),
 
   // Function Calls - common problems encountered calling functions.
   kTvmErrorFunctionCallNumArguments = DEFINE_TVM_CRT_ERROR(kTvmErrorCategoryFunctionCall, 0),

--- a/src/runtime/crt/Makefile
+++ b/src/runtime/crt/Makefile
@@ -66,6 +66,8 @@ $(notdir $(1)): $${BUILD_DIR}/lib$(notdir $(1)).a
 endef
 
 LIBS = \
+	src/runtime/crt/aot_executor \
+	src/runtime/crt/aot_executor_module \
 	src/runtime/crt/common \
 	src/runtime/crt/graph_executor \
 	src/runtime/crt/graph_executor_module \

--- a/src/runtime/crt/aot_executor/aot_executor.c
+++ b/src/runtime/crt/aot_executor/aot_executor.c
@@ -17,26 +17,9 @@
  * under the License.
  */
 
-/*!
- * \file graph_executor_module.h
- * \brief Tiny graph executor that can run graph containing only tvm PackedFunc.
- */
-#ifndef TVM_RUNTIME_CRT_GRAPH_EXECUTOR_MODULE_H_
-#define TVM_RUNTIME_CRT_GRAPH_EXECUTOR_MODULE_H_
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include <tvm/runtime/crt/error_codes.h>
+// LINT_C_FILE
 
 /*!
- * \brief Register the "tvm.graph_executor.create" constructor PackedFunc.
+ * \file aot_executor.c
+ * \brief implement AoT executor in C
  */
-tvm_crt_error_t TVMGraphExecutorModule_Register();
-
-#ifdef __cplusplus
-}  // extern "C"
-#endif
-
-#endif  // TVM_RUNTIME_CRT_GRAPH_EXECUTOR_MODULE_H_

--- a/src/runtime/crt/aot_executor/aot_executor.c
+++ b/src/runtime/crt/aot_executor/aot_executor.c
@@ -95,9 +95,9 @@ int TVMAotExecutor_Init(TVMAotExecutor* executor, TVMModuleHandle module_handle,
   executor->metadata = (TVMMetadata *)get_c_metadata.ret_value.values[0].v_handle;
 
   TVMMetadata* md = executor->metadata;
-  
+
   DumpMetadata(md);
-  
+
   executor->num_args = md->num_inputs + md->num_outputs + md->num_pools;
 
   TVMPlatformMemoryAllocate(executor->num_args * sizeof(*executor->args),
@@ -108,17 +108,8 @@ int TVMAotExecutor_Init(TVMAotExecutor* executor, TVMModuleHandle module_handle,
   for (i = 0; i < md->num_inputs; ++i) {
     fprintf(stderr, "\tinput allocate[%d]: %s\n", i, md->inputs[i].name);
 
-#define FAKE_SHAPE
-
-#ifdef FAKE_SHAPE
-    int64_t shape = 2;
-    TVMNDArray_Empty(1, &shape, md->inputs[i].dtype,
-                     executor->device, &executor->args[arg_idx++]);
-#else
     TVMNDArray_Empty(md->inputs[i].num_shape, md->inputs[i].shape, md->inputs[i].dtype,
                      executor->device, &executor->args[arg_idx++]);
-#endif
-
   }
 
   for (i = 0; i < md->num_outputs; ++i) {

--- a/src/runtime/crt/aot_executor_module/aot_executor_module.c
+++ b/src/runtime/crt/aot_executor_module/aot_executor_module.c
@@ -17,26 +17,25 @@
  * under the License.
  */
 
-/*!
- * \file graph_executor_module.h
- * \brief Tiny graph executor that can run graph containing only tvm PackedFunc.
- */
-#ifndef TVM_RUNTIME_CRT_GRAPH_EXECUTOR_MODULE_H_
-#define TVM_RUNTIME_CRT_GRAPH_EXECUTOR_MODULE_H_
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include <tvm/runtime/crt/error_codes.h>
+// LINT_C_FILE
 
 /*!
- * \brief Register the "tvm.graph_executor.create" constructor PackedFunc.
+ * \file aot_executor_module.c
+ * \brief wrap aot_executor into a TVMModule for use with RPC.
  */
-tvm_crt_error_t TVMGraphExecutorModule_Register();
 
-#ifdef __cplusplus
-}  // extern "C"
-#endif
+#include <tvm/runtime/crt/func_registry.h>
+#include <tvm/runtime/crt/aot_executor.h>
+#include <tvm/runtime/crt/aot_executor_module.h>
+#include <tvm/runtime/crt/module.h>
 
-#endif  // TVM_RUNTIME_CRT_GRAPH_EXECUTOR_MODULE_H_
+int32_t TVMAotExecutorModule_Create(TVMValue* args, int* tcodes, int nargs, TVMValue* ret_values,
+                                      int* ret_tcodes, void* resource_handle) {
+
+  return kTvmErrorNoError;
+}
+
+tvm_crt_error_t TVMAotExecutorModule_Register() {
+
+  return TVMFuncRegisterGlobal("tvm.aot_executor.create", &TVMAotExecutorModule_Create, 0);
+}

--- a/src/runtime/crt/aot_executor_module/aot_executor_module.c
+++ b/src/runtime/crt/aot_executor_module/aot_executor_module.c
@@ -83,6 +83,24 @@ int32_t TVMAotExecutorModule_NotImplemented(TVMValue* args, int* tcodes, int nar
   return kTvmErrorFunctionCallNotImplemented;
 }
 
+int32_t TVMAotExecutorModule_GetInput(TVMValue* args, int* tcodes, int nargs,
+                                      TVMValue* ret_values, int* ret_tcodes,
+                                      void* resource_handle) {
+
+  int index = TVMAotExecutor_GetInputIndex(aot_executor.executor, args[0].v_str);
+
+  fprintf(stderr, "%s: input: %s index: %d\n", __FUNCTION__, args[0].v_str, index);
+
+  if (index < 0) {
+    return kTvmErrorExecutorModuleNoSuchInput;
+  }
+
+  ret_values[0].v_handle = (void*)&aot_executor.executor->args[index].dl_tensor;
+  ret_tcodes[0] = kTVMNDArrayHandle;
+
+  return 0;
+}
+
 int32_t TVMAotExecutorModule_GetInputIndex(TVMValue* args, int* tcodes, int nargs,
                                            TVMValue* ret_values, int* ret_tcodes,
                                            void* resource_handle) {
@@ -99,7 +117,7 @@ int32_t TVMAotExecutorModule_GetInputIndex(TVMValue* args, int* tcodes, int narg
 }
 
 static const TVMBackendPackedCFunc aot_executor_registry_funcs[] = {
-    &TVMAotExecutorModule_NotImplemented,     // get_input
+    &TVMAotExecutorModule_GetInput,           // get_input
     &TVMAotExecutorModule_GetInputIndex,      // get_input_index
     &TVMAotExecutorModule_NotImplemented,     // get_input_info
     &TVMAotExecutorModule_NotImplemented,     // get_num_inputs

--- a/src/runtime/crt/graph_executor_module/graph_executor_module.c
+++ b/src/runtime/crt/graph_executor_module/graph_executor_module.c
@@ -41,7 +41,7 @@ static GraphExecutorModule graph_executor;
 int32_t TVMGraphExecutorModule_Create(TVMValue* args, int* tcodes, int nargs, TVMValue* ret_values,
                                       int* ret_tcodes, void* resource_handle) {
   if (graph_executor.executor != NULL) {
-    return kTvmErrorGraphModuleAlreadyCreated;
+    return kTvmErrorExecutorModuleAlreadyCreated;
   }
 
   if (nargs != 4) {
@@ -54,7 +54,7 @@ int32_t TVMGraphExecutorModule_Create(TVMValue* args, int* tcodes, int nargs, TV
   }
 
   if (args[2].v_int64 != kDLCPU || args[3].v_int64 != 0) {
-    return kTvmErrorGraphModuleBadContext;
+    return kTvmErrorExecutorModuleBadContext;
   }
 
   DLDevice dev = {(DLDeviceType)args[2].v_int64, (int)args[3].v_int64};
@@ -90,7 +90,7 @@ int32_t TVMGraphExecutorModule_GetInput(TVMValue* args, int* tcodes, int nargs,
 
   int index = TVMGraphExecutor_GetInputIndex(graph_executor.executor, args[0].v_str);
   if (index < 0) {
-    return kTvmErrorGraphModuleNoSuchInput;
+    return kTvmErrorExecutorModuleNoSuchInput;
   }
 
   uint32_t eid = TVMGraphExecutor_GetEntryId(graph_executor.executor,
@@ -107,7 +107,7 @@ int32_t TVMGraphExecutorModule_GetInputIndex(TVMValue* args, int* tcodes, int na
   int index = TVMGraphExecutor_GetInputIndex(graph_executor.executor, args[0].v_str);
 
   if (index < 0) {
-    return kTvmErrorGraphModuleNoSuchInput;
+    return kTvmErrorExecutorModuleNoSuchInput;
   }
 
   ret_values[0].v_int64 = index;
@@ -152,7 +152,7 @@ int32_t TVMGraphExecutorModule_GetOutput(TVMValue* args, int* tcodes, int nargs,
 
   int output_index = args[0].v_int64;
   if (output_index < 0 || output_index > TVMGraphExecutor_GetNumOutputs(graph_executor.executor)) {
-    return kTvmErrorGraphModuleNoSuchInput;
+    return kTvmErrorExecutorModuleNoSuchInput;
   }
 
   uint32_t nid = graph_executor.executor->outputs[output_index].node_id;

--- a/src/runtime/crt/graph_executor_module/graph_executor_module.c
+++ b/src/runtime/crt/graph_executor_module/graph_executor_module.c
@@ -100,6 +100,21 @@ int32_t TVMGraphExecutorModule_GetInput(TVMValue* args, int* tcodes, int nargs,
   return 0;
 }
 
+int32_t TVMGraphExecutorModule_GetInputIndex(TVMValue* args, int* tcodes, int nargs,
+                                             TVMValue* ret_values, int* ret_tcodes,
+                                             void* resource_handle) {
+
+  int index = TVMGraphExecutor_GetInputIndex(graph_executor.executor, args[0].v_str);
+
+  if (index < 0) {
+    return kTvmErrorGraphModuleNoSuchInput;
+  }
+
+  ret_values[0].v_int64 = index;
+  ret_tcodes[0] = kTVMArgInt;
+  return 0;
+}
+
 int32_t TVMGraphExecutorModule_GetNumInputs(TVMValue* args, int* tcodes, int nargs,
                                             TVMValue* ret_values, int* ret_tcodes,
                                             void* resource_handle) {
@@ -202,14 +217,22 @@ int32_t TVMGraphExecutorModule_NotImplemented(TVMValue* args, int* tcodes, int n
 }
 
 static const TVMBackendPackedCFunc graph_executor_registry_funcs[] = {
-    &TVMGraphExecutorModule_GetInput,      &TVMGraphExecutorModule_GetNumInputs,
-    &TVMGraphExecutorModule_GetNumOutputs, &TVMGraphExecutorModule_GetOutput,
-    &TVMGraphExecutorModule_LoadParams,    &TVMGraphExecutorModule_Run,
-    &TVMGraphExecutorModule_SetInput,      &TVMGraphExecutorModule_NotImplemented,
+    &TVMGraphExecutorModule_GetInput,      
+    &TVMGraphExecutorModule_GetInputIndex,
+    &TVMGraphExecutorModule_NotImplemented,    // get_input_info
+    &TVMGraphExecutorModule_GetNumInputs,
+    &TVMGraphExecutorModule_GetNumOutputs,
+    &TVMGraphExecutorModule_GetOutput,
+    &TVMGraphExecutorModule_LoadParams,
+    &TVMGraphExecutorModule_Run,
+    &TVMGraphExecutorModule_SetInput,
+    &TVMGraphExecutorModule_NotImplemented,    // share_params
 };
 
 static const TVMFuncRegistry graph_executor_registry = {
     "\x08get_input\0"
+    "get_input_index\0"
+    "get_input_info\0"
     "get_num_inputs\0"
     "get_num_outputs\0"
     "get_output\0"

--- a/src/runtime/crt/host/Makefile
+++ b/src/runtime/crt/host/Makefile
@@ -36,7 +36,13 @@ endif
 
 PWD = $(shell pwd)
 BUILD_DIR = build
-CRT_LIB_NAMES = microtvm_rpc_server microtvm_rpc_common graph_executor_module graph_executor common memory 
+
+CRT_LIB_NAMES = \
+	microtvm_rpc_server microtvm_rpc_common \
+	aot_executor aot_executor_module \
+	graph_executor_module graph_executor \
+	common memory
+
 CRT_LIBS = $(patsubst %, $(BUILD_DIR)/crt/lib%.a, $(CRT_LIB_NAMES))
 
 CRT_INCLUDES = $(glob crt/include/**)

--- a/src/runtime/crt/host/Makefile
+++ b/src/runtime/crt/host/Makefile
@@ -17,11 +17,11 @@
 
 INCLUDES ?= -isystem crt/include -Icrt_config
 CFLAGS ?= -Werror -Wall
-CXXFLAGS ?= -Werror -Wall -std=c++11
+CXXFLAGS ?= -Werror -Wall -std=c++11 -DTVM_HOST_USE_GRAPH_EXECUTOR_MODULE
 LDFLAGS ?= -Werror -Wall
 
 # Codegen produces spurious lines like: int32_t arg2_code = ((int32_t*)arg_type_ids)[(2)];
-MODEL_CFLAGS ?= -Wno-error=unused-variable
+MODEL_CFLAGS ?= -Wno-error=unused-variable -Wno-error=missing-braces
 
 AR ?= ${PREFIX}ar
 CC ?= ${PREFIX}gcc
@@ -36,7 +36,7 @@ endif
 
 PWD = $(shell pwd)
 BUILD_DIR = build
-CRT_LIB_NAMES = microtvm_rpc_server microtvm_rpc_common graph_executor graph_executor_module common memory
+CRT_LIB_NAMES = microtvm_rpc_server microtvm_rpc_common graph_executor_module graph_executor common memory 
 CRT_LIBS = $(patsubst %, $(BUILD_DIR)/crt/lib%.a, $(CRT_LIB_NAMES))
 
 CRT_INCLUDES = $(glob crt/include/**)

--- a/src/runtime/crt/host/Makefile
+++ b/src/runtime/crt/host/Makefile
@@ -39,7 +39,7 @@ BUILD_DIR = build
 
 CRT_LIB_NAMES = \
 	microtvm_rpc_server microtvm_rpc_common \
-	aot_executor aot_executor_module \
+	aot_executor_module aot_executor \
 	graph_executor_module graph_executor \
 	common memory
 

--- a/src/runtime/crt/host/main.cc
+++ b/src/runtime/crt/host/main.cc
@@ -38,6 +38,8 @@
 #include <tvm/runtime/crt/graph_executor_module.h>
 #endif
 
+#include <tvm/runtime/crt/aot_executor_module.h>
+
 using namespace std::chrono;
 
 extern "C" {
@@ -136,6 +138,8 @@ int main(int argc, char** argv) {
   CHECK_EQ(TVMGraphExecutorModule_Register(), kTvmErrorNoError,
            "failed to register GraphExecutor TVMModule");
 #endif
+
+  CHECK_EQ(TVMAotExecutorModule_Register(), kTvmErrorNoError, "failed to register AoT Executor TVMModule");
 
   int error = TVMFuncRegisterGlobal("tvm.testing.reset_server",
                                     (TVMFunctionHandle)&testonly_reset_server, 0);

--- a/tests/python/unittest/test_crt.py
+++ b/tests/python/unittest/test_crt.py
@@ -212,6 +212,9 @@ def test_aot_executor():
         assert aot_executor.get_input_index("a") == 0
         assert aot_executor.get_input_index("b") == 1
 
+        assert aot_executor.get_num_inputs() == 2
+        assert aot_executor.get_num_outputs() == 1
+
         A_np = np.array([[2, 3]], dtype="uint8")
         B_np = np.array([[4, 7]], dtype="uint8")
 
@@ -221,10 +224,11 @@ def test_aot_executor():
         print("A_data: " + str(A_data))
         print("B_data: " + str(B_data))
         
-#        aot_executor["run"]()
+        aot_executor.run()
 
-#        out = aot_executor.get_output(0)
-#        assert (out.numpy() == np.array([6, 10])).all()
+        out = aot_executor.get_output(0)
+        print("out: " + str(out))
+        assert (out.numpy() == np.array([6, 10])).all()
 
     with _make_session(temp_dir, factory) as sess:
         do_test()

--- a/tests/python/unittest/test_crt.py
+++ b/tests/python/unittest/test_crt.py
@@ -168,6 +168,8 @@ def test_graph_executor():
         B_data = tvm.nd.array(np.array([4, 7], dtype="uint8"), device=sess.device)
         assert (B_data.numpy() == np.array([4, 7])).all()
 
+        print(A_data.shape);
+
         assert graph_mod.get_input_index("a") == 0
         assert graph_mod.get_input_index("b") == 1
 
@@ -203,20 +205,29 @@ def test_aot_executor():
     with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
         factory = tvm.relay.build(relay_mod, target=TARGET, runtime=runtime, executor=executor)
 
-    with _make_session(temp_dir, factory) as sess:
+    def do_test():
         aot_executor = tvm.runtime.executor.aot_executor.AotModule(
             sess._rpc.get_function("tvm.aot_executor.create")(sess.get_system_lib(), sess.device))
 
         assert aot_executor.get_input_index("a") == 0
         assert aot_executor.get_input_index("b") == 1
 
-        A_data = aot_executor["get_input"]("a").copyfrom(np.array([2, 3], dtype="uint8"))
-        B_data = aot_executor["get_input"]("b").copyfrom(np.array([4, 7], dtype="uint8"))
+        A_np = np.array([2, 3], dtype="uint8")
+        B_np = np.array([4, 7], dtype="uint8")
 
-        aot_executor["run"]()
+        A_data = aot_executor.get_input("a").copyfrom(A_np)
+        B_data = aot_executor.get_input("b").copyfrom(B_np)
 
-        out = aot_executor["get_output"](0)
-        assert (out.numpy() == np.array([6, 10])).all()
+        print("A_data: " + str(A_data))
+        print("B_data: " + str(B_data))
+        
+#        aot_executor["run"]()
+
+#        out = aot_executor.get_output(0)
+#        assert (out.numpy() == np.array([6, 10])).all()
+
+    with _make_session(temp_dir, factory) as sess:
+        do_test()
 
 
 @tvm.testing.requires_micro

--- a/tests/python/unittest/test_crt.py
+++ b/tests/python/unittest/test_crt.py
@@ -136,7 +136,9 @@ def test_graph_executor():
     ws_root = pathlib.Path(os.path.dirname(__file__) + "/micro-workspace")
     if ws_root.exists():
         shutil.rmtree(ws_root)
-    temp_dir = tvm.contrib.utils.tempdir(ws_root.resolve())
+    with tvm.contrib.utils.TempDirectory.set_keep_for_debug():
+        temp_dir = tvm.contrib.utils.tempdir(ws_root.resolve())
+    # temp_dir = tvm.contrib.utils.tempdir(ws_root.resolve())
     relay_mod = tvm.parser.fromtext(
         """
       #[version = "0.0.5"]
@@ -150,19 +152,30 @@ def test_graph_executor():
     with tvm.transform.PassContext(opt_level=3, config={"tir.disable_vectorize": True}):
         factory = tvm.relay.build(relay_mod, target=TARGET, runtime=runtime)
 
-    with _make_session(temp_dir, factory) as sess:
-        graph_mod = tvm.micro.create_local_graph_executor(
+    def do_test():
+        # graph_mod = tvm.micro.create_local_graph_executor(
+        #     factory.get_graph_json(), sess.get_system_lib(), sess.device
+        # )
+
+        graph_mod = tvm.contrib.graph_executor.create(
             factory.get_graph_json(), sess.get_system_lib(), sess.device
         )
+
         A_data = tvm.nd.array(np.array([2, 3], dtype="uint8"), device=sess.device)
         assert (A_data.numpy() == np.array([2, 3])).all()
         B_data = tvm.nd.array(np.array([4, 7], dtype="uint8"), device=sess.device)
         assert (B_data.numpy() == np.array([4, 7])).all()
 
+        assert graph_mod.get_input_index("a") == 0
+        assert graph_mod.get_input_index("b") == 1
+
         graph_mod.run(a=A_data, b=B_data)
 
         out = graph_mod.get_output(0)
         assert (out.numpy() == np.array([6, 10])).all()
+
+    with _make_session(temp_dir, factory) as sess:
+        do_test()
 
 
 @tvm.testing.requires_micro
@@ -189,7 +202,8 @@ def test_aot_executor():
         factory = tvm.relay.build(relay_mod, target=TARGET, runtime=runtime, executor=executor)
 
     with _make_session(temp_dir, factory) as sess:
-        aot_executor = sess.get_system_lib()
+        aot_executor = tvm.runtime.executor.aot_executor.AotModule(sess._rpc.get_function("tvm.aot_executor.create")())
+
         A_data = aot_executor["get_input"]("a").copyfrom(np.array([2, 3], dtype="uint8"))
         B_data = aot_executor["get_input"]("b").copyfrom(np.array([4, 7], dtype="uint8"))
 

--- a/tests/python/unittest/test_crt.py
+++ b/tests/python/unittest/test_crt.py
@@ -212,8 +212,8 @@ def test_aot_executor():
         assert aot_executor.get_input_index("a") == 0
         assert aot_executor.get_input_index("b") == 1
 
-        A_np = np.array([2, 3], dtype="uint8")
-        B_np = np.array([4, 7], dtype="uint8")
+        A_np = np.array([[2, 3]], dtype="uint8")
+        B_np = np.array([[4, 7]], dtype="uint8")
 
         A_data = aot_executor.get_input("a").copyfrom(A_np)
         B_data = aot_executor.get_input("b").copyfrom(B_np)

--- a/tests/python/unittest/test_crt.py
+++ b/tests/python/unittest/test_crt.py
@@ -158,7 +158,9 @@ def test_graph_executor():
         # )
 
         graph_mod = tvm.contrib.graph_executor.create(
-            factory.get_graph_json(), sess.get_system_lib(), sess.device
+            factory.get_graph_json(),
+            sess.get_system_lib(),
+            sess.device
         )
 
         A_data = tvm.nd.array(np.array([2, 3], dtype="uint8"), device=sess.device)
@@ -202,7 +204,11 @@ def test_aot_executor():
         factory = tvm.relay.build(relay_mod, target=TARGET, runtime=runtime, executor=executor)
 
     with _make_session(temp_dir, factory) as sess:
-        aot_executor = tvm.runtime.executor.aot_executor.AotModule(sess._rpc.get_function("tvm.aot_executor.create")())
+        aot_executor = tvm.runtime.executor.aot_executor.AotModule(
+            sess._rpc.get_function("tvm.aot_executor.create")(sess.get_system_lib(), sess.device))
+
+        assert aot_executor.get_input_index("a") == 0
+        assert aot_executor.get_input_index("b") == 1
 
         A_data = aot_executor["get_input"]("a").copyfrom(np.array([2, 3], dtype="uint8"))
         B_data = aot_executor["get_input"]("b").copyfrom(np.array([4, 7], dtype="uint8"))


### PR DESCRIPTION
cc: @areusch

Here's the initial framework that supports calling: `tvm.runtime.executor.aot_executor.AotModule(sess._rpc.get_function("tvm.aot_executor.create")())
 `